### PR TITLE
Cap buffered SSE for non-stream clients

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -23,3 +23,7 @@ RSP4COPILOT_CONFIG={"version":1,"providers":{"openai":{"apiMode":"openai-respons
 # RSP4COPILOT_MAX_MESSAGES=200
 # DEFAULT_RSP4COPILOT_MAX_INPUT_CHARS=300000
 # RSP4COPILOT_MAX_INPUT_CHARS=300000
+
+# When client sets stream=false, rsp4copilot may need to buffer upstream SSE into a single JSON response.
+# This cap prevents unbounded buffering; set 0 to disable.
+# RESP_MAX_BUFFERED_SSE_BYTES=4194304

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,10 +2,12 @@ import type { Env } from "./common/types";
 
 export type { Env } from "./common/types";
 export {
+  DEFAULT_RESP_MAX_BUFFERED_SSE_BYTES,
   DEFAULT_RSP4COPILOT_MAX_INPUT_CHARS,
   DEFAULT_RSP4COPILOT_MAX_MESSAGES,
   DEFAULT_RSP4COPILOT_MAX_TURNS,
   getRsp4CopilotLimits,
+  getRsp4CopilotStreamLimits,
 } from "./common/limits";
 export { measureOpenAIChatMessages, trimOpenAIChatMessages } from "./common/openai_chat_messages";
 

--- a/src/common/limits.ts
+++ b/src/common/limits.ts
@@ -3,6 +3,7 @@ import type { Env } from "./types";
 export const DEFAULT_RSP4COPILOT_MAX_TURNS = 40;
 export const DEFAULT_RSP4COPILOT_MAX_MESSAGES = 200;
 export const DEFAULT_RSP4COPILOT_MAX_INPUT_CHARS = 300000;
+export const DEFAULT_RESP_MAX_BUFFERED_SSE_BYTES = 4 * 1024 * 1024;
 
 function parseIntEnv(raw: unknown, fallback: number): number {
   if (typeof raw !== "string") return fallback;
@@ -22,3 +23,8 @@ export function getRsp4CopilotLimits(env: Env): { maxTurns: number; maxMessages:
   };
 }
 
+export function getRsp4CopilotStreamLimits(env: Env): { maxBufferedSseBytes: number } {
+  return {
+    maxBufferedSseBytes: parseIntEnv(env?.RESP_MAX_BUFFERED_SSE_BYTES, DEFAULT_RESP_MAX_BUFFERED_SSE_BYTES),
+  };
+}

--- a/src/providers/openai/handle_request.ts
+++ b/src/providers/openai/handle_request.ts
@@ -1,4 +1,4 @@
-import { getRsp4CopilotLimits, jsonError, jsonResponse, logDebug, normalizeAuthValue, redactHeadersForLog } from "../../common";
+import { getRsp4CopilotLimits, getRsp4CopilotStreamLimits, jsonError, jsonResponse, logDebug, normalizeAuthValue, redactHeadersForLog } from "../../common";
 import { handleOpenAIChatCompletionsViaResponses } from "./handle_chat_completions";
 import { handleOpenAITextCompletionsViaResponses } from "./handle_text_completions";
 import { getPromptCachingParams, getReasoningEffort } from "./params";
@@ -57,6 +57,7 @@ export async function handleOpenAIRequest({
   if (debug) logDebug(debug, reqId, "openai upstream headers", { headers: redactHeadersForLog(headers) });
 
   const limits = getRsp4CopilotLimits(env);
+  const streamLimits = getRsp4CopilotStreamLimits(env);
   const reasoningEffort = getReasoningEffort(reqJson, env);
   const promptCache = getPromptCachingParams(reqJson);
 
@@ -69,6 +70,7 @@ export async function handleOpenAIRequest({
       model,
       stream,
       limits,
+      maxBufferedSseBytes: streamLimits.maxBufferedSseBytes,
       reasoningEffort,
       promptCache,
       debug,
@@ -87,6 +89,7 @@ export async function handleOpenAIRequest({
     stream,
     token,
     limits,
+    maxBufferedSseBytes: streamLimits.maxBufferedSseBytes,
     reasoningEffort,
     promptCache,
     debug,
@@ -96,4 +99,3 @@ export async function handleOpenAIRequest({
     extraSystemText,
   });
 }
-


### PR DESCRIPTION
Closes #8.

When client requests stream=false, rsp4copilot may buffer upstream text/event-stream into a single JSON response. This PR adds a byte cap (env: RESP_MAX_BUFFERED_SSE_BYTES) to prevent unbounded buffering and return a clear 502 instructing clients to use stream:true.