### PR TITLE
🛡️ Sentinel: Fix Information Leakage in Error Responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-16 - [Information Leakage in Error Handling]
+**Vulnerability:** The main error handler in `src/workers.ts` was returning raw exception messages to the client in 500 responses.
+**Learning:** Cloudflare Workers' `fetch` handler needs explicit try-catch blocks that sanitize errors, as default behavior might expose internal state.
+**Prevention:** Always catch unhandled exceptions at the top level and return a generic "Internal Server Error" message, while logging details server-side.

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -556,7 +556,8 @@ export default {
       const stack = err instanceof Error ? err.stack : "";
       console.error(`[rsp4copilot][${reqId}] critical error: ${message}`, { stack });
       if (debug) logDebug(debug, reqId, "unhandled exception", { error: message, stack: previewString(stack, 2400) });
-      return withCors(jsonResponse(500, jsonError(`Internal Server Error: ${message}`, "server_error")), corsHeaders);
+      // 🛡️ Sentinel: Sanitize error message to prevent information leakage
+      return withCors(jsonResponse(500, jsonError("Internal Server Error", "server_error")), corsHeaders);
     }
   },
 };


### PR DESCRIPTION
🛡️ Sentinel Security Fix: Information Leakage in Error Handling

**Vulnerability:**
The main `fetch` handler in `src/workers.ts` caught unhandled exceptions and returned `jsonError(\`Internal Server Error: ${message}\`)` to the client. If `message` contained sensitive data (e.g. "Upstream API key missing: sk-..." or internal paths), it would be exposed to the user.

**Fix:**
Modified the catch block to log the full error details to `console.error` (for logs) but return a generic `jsonError("Internal Server Error")` to the client.

**Verification:**
- Verified locally by injecting a mock error `throw new Error("SECRET_LEAK_TEST")`.
- Confirmed that before the fix, the response contained "SECRET_LEAK_TEST".
- Confirmed that after the fix, the response contained only "Internal Server Error".
- Ran `npm run typecheck` to ensure no regressions.

---
*PR created automatically by Jules for task [508384022290179303](https://jules.google.com/task/508384022290179303) started by @Andy963*