### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leak in error handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-17 - Error Handling Information Leak
+**Vulnerability:** The global error handler in `src/workers.ts` was returning raw exception messages to the client, potentially exposing sensitive internal details (e.g., database connection strings, upstream API errors).
+**Learning:** The codebase lacked a centralized error sanitization mechanism and defaulted to exposing full error details, likely for easier debugging during development.
+**Prevention:** Always use a generic error message for client responses in production environments (e.g., "Internal Server Error") and log the detailed error only on the server side. Include a request ID for correlation.

--- a/src/workers.ts
+++ b/src/workers.ts
@@ -556,7 +556,8 @@ export default {
       const stack = err instanceof Error ? err.stack : "";
       console.error(`[rsp4copilot][${reqId}] critical error: ${message}`, { stack });
       if (debug) logDebug(debug, reqId, "unhandled exception", { error: message, stack: previewString(stack, 2400) });
-      return withCors(jsonResponse(500, jsonError(`Internal Server Error: ${message}`, "server_error")), corsHeaders);
+      // Security fix: Do not expose internal error details to client. use reqId for correlation.
+      return withCors(jsonResponse(500, jsonError(`Internal Server Error (Ref: ${reqId})`, "server_error")), corsHeaders);
     }
   },
 };


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix information leak in error handling

**Vulnerability:** The global error handler in `src/workers.ts` was returning raw exception messages to the client, potentially exposing sensitive internal details (e.g., database connection strings, upstream API errors).
**Impact:** Attackers could gain insights into internal system structure or credentials from error messages.
**Fix:** Modified the error handler to return a generic "Internal Server Error" message with a request ID for correlation. Detailed errors are still logged server-side.
**Verification:** Verified by triggering an intentional error and confirming the response contains a generic message and request ID.

---
*PR created automatically by Jules for task [10531018060178400743](https://jules.google.com/task/10531018060178400743) started by @Andy963*